### PR TITLE
feat: implement visit date filtering for client list

### DIFF
--- a/torri-apps/Web-admin/src/Services/users.js
+++ b/torri-apps/Web-admin/src/Services/users.js
@@ -40,6 +40,22 @@ export const usersApi = {
     );
   },
 
+  // Search users with flexible parameters (for advanced filtering)
+  searchUsersWithParams: async (params = {}) => {
+    const endpoint = buildApiEndpoint('users');
+    const requestParams = { limit: 10000, ...params };
+    
+    return withApiErrorHandling(
+      () => api.get(endpoint, { params: requestParams }),
+      {
+        defaultValue: [],
+        transformData: (data) => {
+          return Array.isArray(data) ? data : [];
+        }
+      }
+    );
+  },
+
   // Get user by ID
   getUserById: async (userId) => {
     const endpoint = buildApiEndpoint(`users/${userId}`);


### PR DESCRIPTION
Implements backend service to calculate visit dates from appointment table and integrates with existing client filtering.

## Backend Changes
- Enhanced `/api/v1/users` endpoint with visit date filtering parameters
- Support filtering by last_visit_days (30, 60, 90) and never_visited
- Only completed appointments count as actual visits
- Optimized subqueries for performance with large datasets

## Frontend Changes
- Added visit date filter UI with 4 dropdown options
- Created searchUsersWithParams API method for flexible filtering
- Integrated real-time filtering by visit history
- Removed warnings about backend enhancement needed

## Key Features
- Multi-tenant support with schema-per-tenant isolation
- Efficient database queries using appointment relationships
- Clean API design following existing FastAPI patterns
- Compatible with existing search, role, and label filters

Closes #20

Generated with [Claude Code](https://claude.ai/code)